### PR TITLE
Fresh milk recipe should use a tag

### DIFF
--- a/src/main/resources/data/pamhc2foodcore/recipes/freshmilk_x8.json
+++ b/src/main/resources/data/pamhc2foodcore/recipes/freshmilk_x8.json
@@ -4,7 +4,7 @@
 	"ingredients":
 	[
     {
-      "item": "minecraft:milk_bucket"
+      "tag": "forge:milk/milk"
     }
 
 


### PR DESCRIPTION
Use "forge:milk/milk" tag for fresh milk recipe to support other mods with other variants of milk buckets.